### PR TITLE
dockerfile: fix glob of args passed to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/src/github.com/garethr/kubeval/bin/linux/amd64/kubeval .
 RUN ln -s /kubeval /usr/local/bin/kubeval
-ENTRYPOINT ["/kubeval"]
+RUN printf '#!/bin/sh\n\neval kubeval $@' >> /kubeval.sh
+RUN chmod +x /kubeval.sh
+ENTRYPOINT ["/kubeval.sh"]
 CMD ["--help"]


### PR DESCRIPTION
Previously passing glob strings as the entrypoint arguments could not be
expanded within Docker.

Fixes #100.