### PR TITLE
Fixed build step in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM golang:1.12-alpine as builder
 RUN apk --no-cache add make git
 WORKDIR /
 COPY . /
-RUN make linux
+RUN make build
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/linux/amd64/kubeval .
+COPY --from=builder /bin/kubeval .
 RUN ln -s /kubeval /usr/local/bin/kubeval
 ENTRYPOINT ["/kubeval"]
 CMD ["--help"]

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -6,7 +6,7 @@ RUN make build
 
 FROM bats/bats:v1.1.0
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/linux/amd64/kubeval /usr/local/bin
+COPY --from=builder /bin/kubeval /usr/local/bin
 COPY acceptance.bats /acceptance.bats
 COPY fixtures /fixtures
 RUN "/acceptance.bats"

--- a/Dockerfile.offline
+++ b/Dockerfile.offline
@@ -2,7 +2,7 @@ FROM golang:1.12-alpine as builder
 RUN apk --no-cache add make git
 WORKDIR /
 COPY . /
-RUN make linux
+RUN make build
 
 FROM alpine:latest as schemas
 RUN apk --no-cache add git
@@ -15,7 +15,7 @@ RUN cd kubernetes-json-schema/master && \
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /bin/linux/amd64/kubeval .
+COPY --from=builder /bin/kubeval .
 COPY --from=standalone-schemas /kubernetes-json-schema /schemas/kubernetes-json-schema/master
 COPY --from=standalone-schemas /openshift-json-schema /schemas/openshift-json-schema/master
 ENV KUBEVAL_SCHEMA_LOCATION=file:///schemas


### PR DESCRIPTION
Was messing around with the project and couldn't build the Dockerfiles. My understanding is that they were not updated when the make targets for building was changed from `make linux` = `/bin/linux/amd64/kubeval` to `make build` = `/bin/kubeval` (during the introduction of GoReleaser?). This PR updates the build step in the Dockerfiles. `make docker`, `make acceptance` and `make docker-offline` now work.

Maybe I'm overlooking something, but anyway here's a PR in case it's a valid fix.