### PR TITLE
Basic schema cache

### DIFF
--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -4,6 +4,8 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/xeipuuv/gojsonschema"
 )
 
 func TestValidateBlankInput(t *testing.T) {
@@ -31,6 +33,31 @@ func TestValidateValidInputs(t *testing.T) {
 		filePath, _ := filepath.Abs("../fixtures/" + test)
 		fileContents, _ := ioutil.ReadFile(filePath)
 		_, err := Validate(fileContents, test)
+		if err != nil {
+			t.Errorf("Validate should pass when testing valid configuration in " + test)
+		}
+	}
+}
+
+func TestValidateValidInputsWithCache(t *testing.T) {
+	var tests = []string{
+		"blank.yaml",
+		"comment.yaml",
+		"valid.yaml",
+		"valid.json",
+		"multi_valid.yaml",
+		"int_or_string.yaml",
+		"null_array.yaml",
+		"quantity.yaml",
+		"extra_property.yaml",
+		"full_domain_group.yaml",
+	}
+	schemaCache := make(map[string]*gojsonschema.Schema, 0)
+
+	for _, test := range tests {
+		filePath, _ := filepath.Abs("../fixtures/" + test)
+		fileContents, _ := ioutil.ReadFile(filePath)
+		_, err := ValidateWithCache(fileContents, test, schemaCache)
 		if err != nil {
 			t.Errorf("Validate should pass when testing valid configuration in " + test)
 		}

--- a/main.go
+++ b/main.go
@@ -51,7 +51,8 @@ var RootCmd = &cobra.Command{
 			for scanner.Scan() {
 				buffer.WriteString(scanner.Text() + "\n")
 			}
-			results, err := kubeval.Validate(buffer.Bytes(), viper.GetString("filename"))
+			schemaCache := kubeval.NewSchemaCache()
+			results, err := kubeval.ValidateWithCache(buffer.Bytes(), viper.GetString("filename"), schemaCache)
 			if err != nil {
 				log.Error(err)
 				os.Exit(1)
@@ -62,6 +63,7 @@ var RootCmd = &cobra.Command{
 				log.Error("You must pass at least one file as an argument")
 				os.Exit(1)
 			}
+			schemaCache := kubeval.NewSchemaCache()
 			for _, fileName := range args {
 				filePath, _ := filepath.Abs(fileName)
 				fileContents, err := ioutil.ReadFile(filePath)
@@ -69,7 +71,7 @@ var RootCmd = &cobra.Command{
 					log.Error("Could not open file", fileName)
 					os.Exit(1)
 				}
-				results, err := kubeval.Validate(fileContents, fileName)
+				results, err := kubeval.ValidateWithCache(fileContents, fileName, schemaCache)
 				if err != nil {
 					log.Error(err)
 					os.Exit(1)


### PR DESCRIPTION
When passing in multiple files each schema is downloaded multiple times.

This PR introduces a simple in-memory cache to download required schemas only once during a validation run.

It uses the approach described in https://github.com/xeipuuv/gojsonschema/blob/master/README.md#validation to share load the schema only once.

This reduces the validation time of our ~1k yaml files from 5 mins to ~10s.