### PR TITLE
detect Helm source template from comments

### DIFF
--- a/fixtures/multi_valid_source.yaml
+++ b/fixtures/multi_valid_source.yaml
@@ -1,0 +1,184 @@
+---
+# Source: chart/templates/primary.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-primary
+  labels:
+    app: redis
+    tier: backend
+    role: primary
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: primary
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: redis-primary
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  labels:
+    app: redis
+    role: primary
+    tier: backend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 1
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   app: guestbook
+  #   role: primary
+  #   tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: primary
+        tier: backend
+    spec:
+      containers:
+      - name: primary
+        image: redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+---
+# Source: chart/templates/secondary.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-secondary
+  labels:
+    app: redis
+    tier: backend
+    role: secondary
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+  selector:
+    app: redis
+    tier: backend
+    role: secondary
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: redis-secondary
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  labels:
+    app: redis
+    role: secondary
+    tier: backend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 2
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   app: guestbook
+  #   role: secondary
+  #   tier: backend
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: secondary
+        tier: backend
+    spec:
+      containers:
+      - name: secondary
+        image: gcr.io/google_samples/gb-redissecondary:v1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access an environment variable to find the primary
+          # service's host, comment out the 'value: dns' line above, and
+          # uncomment the line below.
+          # value: env
+        ports:
+        - containerPort: 6379
+---
+# Source: chart/templates/frontend.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # if your cluster supports it, uncomment the following to automatically create
+  # an external load-balanced IP for the frontend service.
+  # type: LoadBalancer
+  ports:
+    # the port that this service should serve on
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: frontend
+  # these labels can be applied automatically
+  # from the labels in the pod template if not set
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # this replicas value is default
+  # modify it according to your case
+  replicas: 3
+  # selector can be applied automatically
+  # from the labels in the pod template if not set
+  # selector:
+  #   app: guestbook
+  #   tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: gcr.io/google_samples/gb-frontend:v3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: GET_HOSTS_FROM
+          value: dns
+          # If your cluster config does not include a dns service, then to
+          # instead access environment variables to find service host
+          # info, comment out the 'value: dns' line above, and uncomment the
+          # line below.
+          # value: env
+        ports:
+        - containerPort: 80
+---
+---
+# an empty resource with comments
+---

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -254,17 +255,29 @@ func ValidateWithCache(config []byte, fileName string, schemaCache map[string]*g
 
 	bits := bytes.Split(config, []byte(detectLineBreak(config)+"---"+detectLineBreak(config)))
 
+	// special case regexp for helm
+	helmSourcePattern := regexp.MustCompile(`^(?:---` + detectLineBreak(config) + `)?# Source: (.*)`)
+
 	var errors *multierror.Error
+
+	// Start with the filename we were provided; if we detect a new filename
+	// we'll use that until we find a new one.
+	detectedFileName := fileName
+
 	for _, element := range bits {
 		if len(element) > 0 {
-			result, err := validateResource(element, fileName, schemaCache)
+			if found := helmSourcePattern.FindStringSubmatch(string(element)); found != nil {
+				detectedFileName = found[1]
+			}
+
+			result, err := validateResource(element, detectedFileName, schemaCache)
 			results = append(results, result)
 			if err != nil {
 				errors = multierror.Append(errors, err)
 			}
 		} else {
 			result := ValidationResult{}
-			result.FileName = fileName
+			result.FileName = detectedFileName
 			results = append(results, result)
 		}
 	}

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -79,6 +79,30 @@ func TestValidateInvalidInputs(t *testing.T) {
 	}
 }
 
+func TestValidateSourceExtraction(t *testing.T) {
+	expectedFileNames := []string{
+		"chart/templates/primary.yaml",   // first from primary template
+		"chart/templates/primary.yaml",   // second resource from primary template
+		"chart/templates/secondary.yaml", // first resource from secondary template
+		"chart/templates/secondary.yaml", // second resource from secondary template
+		"chart/templates/frontend.yaml",  // first resource from frontend template
+		"chart/templates/frontend.yaml",  // second resource from frontend template
+		"chart/templates/frontend.yaml",  // empty resource no comment
+		"chart/templates/frontend.yaml",  // empty resource with comment
+	}
+	filePath, _ := filepath.Abs("../fixtures/multi_valid_source.yaml")
+	fileContents, _ := ioutil.ReadFile(filePath)
+	results, err := Validate(fileContents, "multi_valid_source.yaml")
+	if err != nil {
+		t.Fatalf("Unexpected error while validating source: %v", err)
+	}
+	for i, r := range results {
+		if r.FileName != expectedFileNames[i] {
+			t.Errorf("%v: expected filename [%v], got [%v]", i, expectedFileNames[i], r.FileName)
+		}
+	}
+}
+
 func TestStrictCatchesAdditionalErrors(t *testing.T) {
 	Strict = true
 	filePath, _ := filepath.Abs("../fixtures/extra_property.yaml")


### PR DESCRIPTION
Helm provides the name of the source template in a comment at the top
of each document, for example:

```yaml
# Source: chart/templates/kind.yaml
...
```

It is helpful to have this filename in the results when we can detect it.