### PR TITLE
This fixes the --ignore-missing-schemas flag

### DIFF
--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -163,12 +163,17 @@ func TestDetermineKind(t *testing.T) {
 }
 
 func TestSkipCrdSchemaMiss(t *testing.T) {
-	IgnoreMissingSchemas = true
 	filePath, _ := filepath.Abs("../fixtures/test_crd.yaml")
 	fileContents, _ := ioutil.ReadFile(filePath)
+	_, err := Validate(fileContents, "test_crd.yaml")
+	if err == nil {
+		t.Errorf("For custom CRD's with schema missing we should error without IgnoreMissingSchemas flag")
+	}
+
+	IgnoreMissingSchemas = true
 	results, _ := Validate(fileContents, "test_crd.yaml")
 	if len(results[0].Errors) != 0 {
-		t.Errorf("For custom CRD's with schema missing we should skip with SkipCrdSchemaMiss flag")
+		t.Errorf("For custom CRD's with schema missing we should skip with IgnoreMissingSchemas flag")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -95,6 +95,8 @@ func logResults(results []kubeval.ValidationResult, success bool) bool {
 			}
 		} else if result.Kind == "" {
 			log.Success("The document", result.FileName, "is empty")
+		} else if !result.ValidatedAgainstSchema {
+			log.Warn("The document", result.FileName, "containing a", result.Kind, "was not validated against a schema")
 		} else {
 			log.Success("The document", result.FileName, "contains a valid", result.Kind)
 		}


### PR DESCRIPTION
Addresses https://github.com/instrumenta/kubeval/issues/149

This changes the behavior of the `--ignore-missing-schemas` flag. Prior to
this change, the flag prevented validation against schemas for all
documents. The new behavior is to prevent validation against schemas for
any document whose associated schema can not be found. All other
documents are validated against their corresponding schemas.

This also improves the expected behavior of the flag. Prior behavior was
to display a successful message for any document missing its schema. New
behavior will print a warning message that the document was not
validated against a schema. Note that this still returns a success code.

The following demostrates the new behavior against the `valid.yaml`, `invalid.yaml`, and `test_crd.yaml` files located in the `fixtures` directory: 

```
$ kubeval fixtures/valid.yaml
The document fixtures/valid.yaml contains a valid ReplicationController

$ kubeval fixtures/valid.yaml --ignore-missing-schemas
Warning: Set to ignore missing schemas
The document fixtures/valid.yaml contains a valid ReplicationController


$ kubeval fixtures/invalid.yaml
The document fixtures/invalid.yaml contains an invalid ReplicationController
---> spec.replicas: Invalid type. Expected: integer, given: string

$ kubeval fixtures/invalid.yaml --ignore-missing-schemas
Warning: Set to ignore missing schemas
The document fixtures/invalid.yaml contains an invalid ReplicationController
---> spec.replicas: Invalid type. Expected: integer, given: string


$ kubeval fixtures/test_crd.yaml
1 error occurred:
        * Failed initalizing schema https://kubernetesjsonschema.dev/master-standalone/sealedsecret-bitnami-v1alpha1.json: Could not read schema from HTTP, response status is 404 Not Found

$ kubeval fixtures/test_crd.yaml --ignore-missing-schemas
Warning: Set to ignore missing schemas
The document fixtures/test_crd.yaml containing a SealedSecret was not validated against a schema
```