### PR TITLE
Add the --skip-kinds flag

### DIFF
--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -42,6 +42,20 @@ var Strict bool
 // for resource definitions without an available schema
 var IgnoreMissingSchemas bool
 
+// KindsToSkip is a list of kubernetes resources types with which to skip
+// schema validation
+var KindsToSkip []string
+
+// in is a method which tests whether the `key` is in the set
+func in(set []string, key string) bool {
+	for _, k := range set {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidFormat is a type for quickly forcing
 // new formats on the gojsonschema loader
 type ValidFormat struct{}
@@ -188,6 +202,10 @@ func validateResource(data []byte, fileName string, schemaCache map[string]*gojs
 		return result, err
 	}
 	result.APIVersion = apiVersion
+
+	if in(KindsToSkip, kind) {
+		return result, nil
+	}
 
 	schemaRef := determineSchema(kind, apiVersion)
 

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -168,7 +168,14 @@ func TestSkipCrdSchemaMiss(t *testing.T) {
 	fileContents, _ := ioutil.ReadFile(filePath)
 	results, _ := Validate(fileContents, "test_crd.yaml")
 	if len(results[0].Errors) != 0 {
-		t.Errorf("For custom CRD's with schema missing we should skip with SkipCrdSchemaMiss flag")
+		t.Errorf("For custom CRD's with schema missing we should skip with IgnoreMissingSchemas flag")
+	}
+
+	IgnoreMissingSchemas = false
+	KindsToSkip = []string{"SealedSecret"}
+	results, _ = Validate(fileContents, "test_crd.yaml")
+	if len(results[0].Errors) != 0 {
+		t.Errorf("We should skip resources listed in KindsToSkip")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -119,6 +119,7 @@ func init() {
 	RootCmd.Flags().BoolVarP(&kubeval.OpenShift, "openshift", "", false, "Use OpenShift schemas instead of upstream Kubernetes")
 	RootCmd.Flags().BoolVarP(&kubeval.Strict, "strict", "", false, "Disallow additional properties not in schema")
 	RootCmd.Flags().BoolVarP(&kubeval.IgnoreMissingSchemas, "ignore-missing-schemas", "", false, "Skip validation for resource definitions without a schema")
+	RootCmd.Flags().StringSliceVar(&kubeval.KindsToSkip, "skip-kinds", []string{}, "Comma-separated list of case-sensitive kinds to skip when validating against schemas")
 	RootCmd.SetVersionTemplate(`{{.Version}}`)
 	viper.BindPFlag("schema_location", RootCmd.Flags().Lookup("schema-location"))
 	RootCmd.PersistentFlags().StringP("filename", "f", "stdin", "filename to be displayed when testing manifests read from stdin")


### PR DESCRIPTION
This adds the skip-kinds flag which expects a comma-separated list of
kubernetes resources (labeled by case-sensitive Kind) for which to skip
schema validation. This is useful when validating CRDs for which the
user may not have a schema.