### PR TITLE
Update to sigs.k8s.io/yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,5 +28,6 @@ require (
 	github.com/xeipuuv/gojsonschema v0.0.0-20180816142147-da425ebb7609
 	golang.org/x/sys v0.0.0-20180821044426-4ea2f632f6e9 // indirect
 	golang.org/x/text v0.0.0-20180810153555-6e3c4e7365dd // indirect
-	gopkg.in/yaml.v2 v2.2.1
+	gopkg.in/yaml.v2 v2.2.1 // indirect
+	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -56,3 +56,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
+sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -211,10 +211,55 @@ func TestDetermineSchemaForSchemaLocation(t *testing.T) {
 	}
 }
 
-func TestDetermineKind(t *testing.T) {
-	_, err := determineKind("sample")
-	if err == nil {
-		t.Errorf("Shouldn't be able to find a kind when passed a blank string")
+func TestGetString(t *testing.T) {
+	var tests = []struct{
+		body map[string]interface{}
+		key string
+		expectedVal string
+		expectError bool
+	}{
+		{
+			body: map[string]interface{}{"goodKey": "goodVal"},
+			key: "goodKey",
+			expectedVal: "goodVal",
+			expectError: false,
+		},
+		{
+			body: map[string]interface{}{},
+			key: "missingKey",
+			expectedVal: "",
+			expectError: true,
+		},
+		{
+			body: map[string]interface{}{"nilKey": nil},
+			key: "nilKey",
+			expectedVal: "",
+			expectError: true,
+		},
+		{
+			body: map[string]interface{}{"badKey": 5},
+			key: "badKey",
+			expectedVal: "",
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		actualVal, err := getString(test.body, test.key)
+		if err != nil {
+			if !test.expectError {
+				t.Errorf("Unexpected error: %s", err.Error())
+			}
+			// We expected this error, so move to the next test
+			continue
+		}
+		if test.expectError {
+			t.Errorf("Expected an error, but didn't receive one")
+			continue
+		}
+		if actualVal != test.expectedVal {
+			t.Errorf("Expected %s, got %s", test.expectedVal, actualVal)
+		}
 	}
 }
 


### PR DESCRIPTION
This updates the current YAML library from gopkg.in/yaml.v2 to
sigs.k8s.io/yaml, a wrapper around the former. The k8s library provides
better functionality with regards to unmarshaling a YAML file into a
JSON-friendly data structure.

This commit also includes various cleanups related to the change:
* `convertToStringKeys` has been removed
* functions `determineKind` and `determineAPIVersion` have been replaced
  by the more generic `getString`
* functions `in`, `detectLineBreak` and `getString` have been moved to
  kubeval/utils.go

Lastly, unit tests have been written for the new `getString` function