### PR TITLE
Move configuration into a Config object

### DIFF
--- a/kubeval/config.go
+++ b/kubeval/config.go
@@ -1,0 +1,65 @@
+package kubeval
+
+import "github.com/spf13/cobra"
+
+// DefaultSchemaLocation is the default location to search for schemas
+const DefaultSchemaLocation = "https://kubernetesjsonschema.dev"
+
+// OpenShiftSchemaLocation is the alternative location for OpenShift specific schemas
+const OpenShiftSchemaLocation = "https://raw.githubusercontent.com/garethr/openshift-json-schema/master"
+
+// A Config object contains various configuration data for kubeval
+type Config struct {
+	// KubernetesVersion represents the version of Kubernetes
+	// for which we should load the schema
+	KubernetesVersion string
+
+	// SchemaLocation is the base URL from which to search for schemas.
+	// It can be either a remote location or a local directory
+	SchemaLocation string
+
+	// OpenShift represents whether to test against
+	// upstream Kubernetes or the OpenShift schemas
+	OpenShift bool
+
+	// Strict tells kubeval whether to prohibit properties not in
+	// the schema. The API allows them, but kubectl does not
+	Strict bool
+
+	// IgnoreMissingSchemas tells kubeval whether to skip validation
+	// for resource definitions without an available schema
+	IgnoreMissingSchemas bool
+
+	// ExitOnError tells kubeval whether to halt processing upon the
+	// first error encountered or to continue, aggregating all errors
+	ExitOnError bool
+
+	// KindsToSkip is a list of kubernetes resources types with which to skip
+	// schema validation
+	KindsToSkip []string
+
+	// FileName is the name to be displayed when testing manifests read from stdin
+	FileName string
+}
+
+
+// NewDefaultConfig creates a Config with default values
+func NewDefaultConfig() *Config {
+	return &Config{
+		FileName: "stdin",
+		KubernetesVersion: "master",
+	}
+}
+
+// AddKubevalFlags adds the default flags for kubeval to cmd
+func AddKubevalFlags(cmd *cobra.Command, config *Config) *cobra.Command {
+	cmd.Flags().BoolVar(&config.ExitOnError, "exit-on-error", false, "Immediately stop execution when the first error is encountered")
+	cmd.Flags().BoolVar(&config.IgnoreMissingSchemas, "ignore-missing-schemas", false, "Skip validation for resource definitions without a schema")
+	cmd.Flags().BoolVar(&config.OpenShift, "openshift", false, "Use OpenShift schemas instead of upstream Kubernetes")
+	cmd.Flags().BoolVar(&config.Strict, "strict", false, "Disallow additional properties not in schema")
+	cmd.Flags().StringP("filename", "f", "stdin", "filename to be displayed when testing manifests read from stdin")
+	cmd.Flags().StringSliceVar(&config.KindsToSkip, "skip-kinds", []string{}, "Comma-separated list of case-sensitive kinds to skip when validating against schemas")
+	cmd.Flags().StringVar(&config.SchemaLocation, "schema-location", "", "Base URL used to download schemas. Can also be specified with the environment variable KUBEVAL_SCHEMA_LOCATION")
+	cmd.Flags().StringVarP(&config.KubernetesVersion, "kubernetes-version", "v", "master", "Version of Kubernetes to validate against")
+	return cmd
+}

--- a/kubeval/config.go
+++ b/kubeval/config.go
@@ -57,7 +57,7 @@ func AddKubevalFlags(cmd *cobra.Command, config *Config) *cobra.Command {
 	cmd.Flags().BoolVar(&config.IgnoreMissingSchemas, "ignore-missing-schemas", false, "Skip validation for resource definitions without a schema")
 	cmd.Flags().BoolVar(&config.OpenShift, "openshift", false, "Use OpenShift schemas instead of upstream Kubernetes")
 	cmd.Flags().BoolVar(&config.Strict, "strict", false, "Disallow additional properties not in schema")
-	cmd.Flags().StringP("filename", "f", "stdin", "filename to be displayed when testing manifests read from stdin")
+	cmd.Flags().StringVarP(&config.FileName, "filename", "f", "stdin", "filename to be displayed when testing manifests read from stdin")
 	cmd.Flags().StringSliceVar(&config.KindsToSkip, "skip-kinds", []string{}, "Comma-separated list of case-sensitive kinds to skip when validating against schemas")
 	cmd.Flags().StringVar(&config.SchemaLocation, "schema-location", "", "Base URL used to download schemas. Can also be specified with the environment variable KUBEVAL_SCHEMA_LOCATION")
 	cmd.Flags().StringVarP(&config.KubernetesVersion, "kubernetes-version", "v", "master", "Version of Kubernetes to validate against")

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -2,10 +2,12 @@ package kubeval
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -107,23 +109,23 @@ func TestValidateSourceExtraction(t *testing.T) {
 }
 
 func TestStrictCatchesAdditionalErrors(t *testing.T) {
-	Strict = true
+	config := NewDefaultConfig()
+	config.Strict = true
 	filePath, _ := filepath.Abs("../fixtures/extra_property.yaml")
 	fileContents, _ := ioutil.ReadFile(filePath)
-	results, _ := Validate(fileContents, "extra_property.yaml")
+	results, _ := Validate(fileContents, "extra_property.yaml", config)
 	if len(results[0].Errors) == 0 {
 		t.Errorf("Validate should not pass when testing for additional properties not in schema")
 	}
 }
 
 func TestValidateMultipleVersions(t *testing.T) {
-	Strict = true
-	Version = "1.14.0"
-	OpenShift = false
+	config := NewDefaultConfig()
+	config.Strict = true
+	config.KubernetesVersion = "1.14.0"
 	filePath, _ := filepath.Abs("../fixtures/valid_version.yaml")
 	fileContents, _ := ioutil.ReadFile(filePath)
-	results, err := Validate(fileContents, "valid_version.yaml")
-	Version = ""
+	results, err := Validate(fileContents, "valid_version.yaml", config)
 	if err != nil || len(results[0].Errors) > 0 {
 		t.Errorf("Validate should pass when testing valid configuration with multiple versions: %v", err)
 	}
@@ -149,10 +151,11 @@ func TestValidateMultipleResourcesWithErrors(t *testing.T) {
 		"multi_invalid_resources.yaml",
 	}
 	for _, test := range tests {
+		config := NewDefaultConfig()
 		filePath, _ := filepath.Abs("../fixtures/" + test)
 		fileContents, _ := ioutil.ReadFile(filePath)
-		ExitOnError = true
-		_, err := Validate(fileContents, test)
+		config.ExitOnError = true
+		_, err := Validate(fileContents, test, config)
 		if err == nil {
 			t.Errorf("Validate should not pass when testing invalid configuration in " + test)
 		} else if merr, ok := err.(*multierror.Error); ok {
@@ -160,8 +163,8 @@ func TestValidateMultipleResourcesWithErrors(t *testing.T) {
 				t.Errorf("Validate should encounter exactly 1 error when testing invalid configuration in " + test + " with ExitOnError=true")
 			}
 		}
-		ExitOnError = false
-		_, err = Validate(fileContents, test)
+		config.ExitOnError = false
+		_, err = Validate(fileContents, test, config)
 		if err == nil {
 			t.Errorf("Validate should not pass when testing invalid configuration in " + test)
 		} else if merr, ok := err.(*multierror.Error); ok {
@@ -175,36 +178,53 @@ func TestValidateMultipleResourcesWithErrors(t *testing.T) {
 }
 
 func TestDetermineSchema(t *testing.T) {
-	Strict = false
-	schema := determineSchema("sample", "v1")
+	config := NewDefaultConfig()
+	schema := determineSchema("sample", "v1", config)
 	if schema != "https://kubernetesjsonschema.dev/master-standalone/sample-v1.json" {
 		t.Errorf("Schema should default to master, instead %s", schema)
 	}
 }
 
 func TestDetermineSchemaForVersions(t *testing.T) {
-	Version = "1.0"
-	OpenShift = false
-	schema := determineSchema("sample", "v1")
+	config := NewDefaultConfig()
+	config.KubernetesVersion = "1.0"
+	schema := determineSchema("sample", "v1", config)
 	if schema != "https://kubernetesjsonschema.dev/v1.0-standalone/sample-v1.json" {
 		t.Errorf("Should be able to specify a version, instead %s", schema)
 	}
 }
 
 func TestDetermineSchemaForOpenShift(t *testing.T) {
-	OpenShift = true
-	Version = "master"
-	schema := determineSchema("sample", "v1")
+	config := NewDefaultConfig()
+	config.OpenShift = true
+	schema := determineSchema("sample", "v1", config)
 	if schema != "https://raw.githubusercontent.com/garethr/openshift-json-schema/master/master-standalone/sample.json" {
 		t.Errorf("Should be able to toggle to OpenShift schemas, instead %s", schema)
 	}
 }
 
 func TestDetermineSchemaForSchemaLocation(t *testing.T) {
-	OpenShift = false
-	Version = "master"
-	SchemaLocation = "file:///home/me"
-	schema := determineSchema("sample", "v1")
+	config := NewDefaultConfig()
+	config.SchemaLocation = "file:///home/me"
+	schema := determineSchema("sample", "v1", config)
+	expectedSchema := "file:///home/me/master-standalone/sample-v1.json"
+	if schema != expectedSchema {
+		t.Errorf("Should be able to specify a schema location, expected %s, got %s instead ", expectedSchema, schema)
+	}
+}
+
+func TestDetermineSchemaForEnvVariable(t *testing.T) {
+	oldVal, found := os.LookupEnv("KUBEVAL_SCHEMA_LOCATION")
+	defer func() {
+		if found {
+			os.Setenv("KUBEVAL_SCHEMA_LOCATION", oldVal)
+		} else {
+			os.Unsetenv("KUBEVAL_SCHEMA_LOCATION")
+		}
+	}()
+	config := NewDefaultConfig()
+	os.Setenv("KUBEVAL_SCHEMA_LOCATION", "file:///home/me")
+	schema := determineSchema("sample", "v1", config)
 	expectedSchema := "file:///home/me/master-standalone/sample-v1.json"
 	if schema != expectedSchema {
 		t.Errorf("Should be able to specify a schema location, expected %s, got %s instead ", expectedSchema, schema)
@@ -271,16 +291,42 @@ func TestSkipCrdSchemaMiss(t *testing.T) {
 		t.Errorf("For custom CRD's with schema missing we should error without IgnoreMissingSchemas flag")
 	}
 
-	IgnoreMissingSchemas = true
-	results, _ := Validate(fileContents, "test_crd.yaml")
+	config := NewDefaultConfig()
+	config.IgnoreMissingSchemas = true
+	results, _ := Validate(fileContents, "test_crd.yaml", config)
 	if len(results[0].Errors) != 0 {
 		t.Errorf("For custom CRD's with schema missing we should skip with IgnoreMissingSchemas flag")
 	}
 
-	IgnoreMissingSchemas = false
-	KindsToSkip = []string{"SealedSecret"}
-	results, _ = Validate(fileContents, "test_crd.yaml")
+	config.IgnoreMissingSchemas = false
+	config.KindsToSkip = []string{"SealedSecret"}
+	results, _ = Validate(fileContents, "test_crd.yaml", config)
 	if len(results[0].Errors) != 0 {
 		t.Errorf("We should skip resources listed in KindsToSkip")
+	}
+}
+
+func TestFlagAdding(t *testing.T) {
+	cmd := &cobra.Command{}
+	config := &Config{}
+
+	AddKubevalFlags(cmd, config)
+
+	expectedFlags := []string{
+		"exit-on-error",
+		"ignore-missing-schemas",
+		"openshift",
+		"strict",
+		"filename",
+		"skip-kinds",
+		"schema-location",
+		"kubernetes-version",
+	}
+
+	for _, expected := range expectedFlags {
+		flag := cmd.Flags().Lookup(expected)
+		if flag == nil {
+			t.Errorf("Could not find flag '%s'", expected)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -66,7 +66,8 @@ var RootCmd = &cobra.Command{
 				buffer.WriteString(scanner.Text() + "\n")
 			}
 			schemaCache := kubeval.NewSchemaCache()
-			results, err := kubeval.ValidateWithCache(buffer.Bytes(), viper.GetString("filename"), schemaCache, config)
+			config.FileName = viper.GetString("filename")
+			results, err := kubeval.ValidateWithCache(buffer.Bytes(), schemaCache, config)
 			if err != nil {
 				log.Error(err)
 				os.Exit(1)
@@ -92,7 +93,8 @@ var RootCmd = &cobra.Command{
 					success = false
 					continue
 				}
-				results, err := kubeval.ValidateWithCache(fileContents, fileName, schemaCache, config)
+				config.FileName = fileName
+				results, err := kubeval.ValidateWithCache(fileContents, schemaCache, config)
 				if err != nil {
 					log.Error(err)
 					earlyExit()


### PR DESCRIPTION
This commit introduces the `Config` object, which contains all the
configuration information that `kubeval.Validate` might need. The default
settings can be obtained by using the `NewDefaultConfig` function.
Functions `Validate` and `ValidateWithCache` have been modified to
accept an optional Config object - if none is provided, the default is
used.

Unit tests have also been updated to reflect these changes.

Note that these changes also pass the newly added acceptance tests in https://github.com/instrumenta/kubeval/pull/157