### PR TITLE
Fix stuttering output when supplying multiple files as input

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,6 @@ var RootCmd = &cobra.Command{
 					os.Exit(1)
 				}
 			}
-
 		} else {
 			if len(args) < 1 && len(directories) < 1 {
 				log.Error("You must pass at least one file as an argument, or at least one directory to the directories flag")
@@ -143,6 +142,8 @@ var RootCmd = &cobra.Command{
 	},
 }
 
+// hasErrors returns truthy if any of the provided results
+// contain errors.
 func hasErrors(res []kubeval.ValidationResult) bool {
 	for _, r := range res {
 		if len(r.Errors) > 0 {

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ var RootCmd = &cobra.Command{
 				log.Error(err)
 				os.Exit(1)
 			}
-			success = isSuccess(results)
+			success = !hasErrors(results)
 
 			for _, r := range results {
 				err = outputManager.Put(r)
@@ -126,8 +126,8 @@ var RootCmd = &cobra.Command{
 				aggResults = append(aggResults, results...)
 			}
 
-			// only use result of isSuccess check if `success` is currently truthy
-			success = success && isSuccess(aggResults)
+			// only use result of hasErrors check if `success` is currently truthy
+			success = success && !hasErrors(aggResults)
 		}
 
 		// flush any final logs which may be sitting in the buffer
@@ -143,13 +143,13 @@ var RootCmd = &cobra.Command{
 	},
 }
 
-func isSuccess(res []kubeval.ValidationResult) bool {
+func hasErrors(res []kubeval.ValidationResult) bool {
 	for _, r := range res {
 		if len(r.Errors) > 0 {
-			return false
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 func aggregateFiles(args []string) ([]string, error) {

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ var RootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		success := true
 		windowsStdinIssue := false
+		outputManager := kubeval.GetOutputManager(config.OutputFormat)
+
 		stat, err := os.Stdin.Stat()
 		if err != nil {
 			// Stat() will return an error on Windows in both Powershell and
@@ -72,11 +74,16 @@ var RootCmd = &cobra.Command{
 				log.Error(err)
 				os.Exit(1)
 			}
-			success, err = logResults(config.OutputFormat, results, success)
-			if err != nil {
-				log.Error(err)
-				os.Exit(1)
+			success = isSuccess(results)
+
+			for _, r := range results {
+				err = outputManager.Put(r)
+				if err != nil {
+					log.Error(err)
+					os.Exit(1)
+				}
 			}
+
 		} else {
 			if len(args) < 1 && len(directories) < 1 {
 				log.Error("You must pass at least one file as an argument, or at least one directory to the directories flag")
@@ -88,6 +95,8 @@ var RootCmd = &cobra.Command{
 				log.Error(err.Error())
 				success = false
 			}
+
+			var aggResults []kubeval.ValidationResult
 			for _, fileName := range files {
 				filePath, _ := filepath.Abs(fileName)
 				fileContents, err := ioutil.ReadFile(filePath)
@@ -105,40 +114,42 @@ var RootCmd = &cobra.Command{
 					success = false
 					continue
 				}
-				success, err = logResults(config.OutputFormat, results, success)
-				if err != nil {
-					log.Error(err)
-					os.Exit(1)
+
+				for _, r := range results {
+					err := outputManager.Put(r)
+					if err != nil {
+						log.Error(err)
+						os.Exit(1)
+					}
 				}
 
+				aggResults = append(aggResults, results...)
 			}
+
+			// only use result of isSuccess check if `success` is currently truthy
+			success = success && isSuccess(aggResults)
 		}
+
+		// flush any final logs which may be sitting in the buffer
+		err = outputManager.Flush()
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
+
 		if !success {
 			os.Exit(1)
 		}
 	},
 }
 
-func logResults(outFmt string, results []kubeval.ValidationResult, success bool) (bool, error) {
-	// fetch output logger based on enviroments params
-	out := kubeval.GetOutputManager(outFmt)
-
-	for _, result := range results {
-		if len(result.Errors) > 0 {
-			success = false
-		}
-		err := out.Put(result)
-		if err != nil {
-			return success, err
+func isSuccess(res []kubeval.ValidationResult) bool {
+	for _, r := range res {
+		if len(r.Errors) > 0 {
+			return false
 		}
 	}
-
-	err := out.Flush()
-	if err != nil {
-		return false, err
-	}
-
-	return success, nil
+	return true
 }
 
 func aggregateFiles(args []string) ([]string, error) {


### PR DESCRIPTION
Fixes a logging control flow bug which would result in multiple "output sets" being produced when supplying multiple input files. For example, an invocation with three files and `-o json` would produce three distinct arrays of output, instead of a single array.

**Before:**
```console
⇒  ./bin/kubeval -o json fixtures/valid.yaml fixtures/invalid.yaml
[
        {
                "filename": "fixtures/valid.yaml",
                "kind": "ReplicationController",
                "status": "valid",
                "errors": []
        }
]
[
        {
                "filename": "fixtures/invalid.yaml",
                "kind": "ReplicationController",
                "status": "invalid",
                "errors": [
                        "spec.replicas: Invalid type. Expected: [integer,null], given: string"
                ]
        }
]
```

**After:**

```console
⇒  bin/kubeval -o json fixtures/valid.yaml fixtures/valid.yaml
[
        {
                "filename": "fixtures/valid.yaml",
                "kind": "ReplicationController",
                "status": "valid",
                "errors": []
        },
        {
                "filename": "fixtures/valid.yaml",
                "kind": "ReplicationController",
                "status": "valid",
                "errors": []
        }
]
```

```console
⇒  ./bin/kubeval -o json fixtures/valid.yaml fixtures/invalid.yaml fixtures/multi_valid.yaml 
[
        {
                "filename": "fixtures/valid.yaml",
                "kind": "ReplicationController",
                "status": "valid",
                "errors": []
        },
        {
                "filename": "fixtures/invalid.yaml",
                "kind": "ReplicationController",
                "status": "invalid",
                "errors": [
                        "spec.replicas: Invalid type. Expected: [integer,null], given: string"
                ]
        },
        {
                "filename": "fixtures/multi_valid.yaml",
                "kind": "Service",
                "status": "valid",
                "errors": []
        },
        {
                "filename": "fixtures/multi_valid.yaml",
                "kind": "ReplicationController",
                "status": "valid",
                "errors": []
        },
        {
                "filename": "fixtures/multi_valid.yaml",
                "kind": "Service",
                "status": "valid",
                "errors": []
        },
        {
                "filename": "fixtures/multi_valid.yaml",
                "kind": "ReplicationController",
                "status": "valid",
                "errors": []
        },
        {
                "filename": "fixtures/multi_valid.yaml",
                "kind": "Service",
                "status": "valid",
                "errors": []
        },
        {
                "filename": "fixtures/multi_valid.yaml",
                "kind": "ReplicationController",
                "status": "valid",
                "errors": []
        },
        {
                "filename": "fixtures/multi_valid.yaml",
                "kind": "",
                "status": "skipped",
                "errors": []
        },
        {
                "filename": "fixtures/multi_valid.yaml",
                "kind": "",
                "status": "skipped",
                "errors": []
        }
]
```