### PR TITLE
adds a quiet flag

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -163,3 +163,9 @@
   [[ "${lines[1]}" == *"The file fixtures/valid.yaml contains a valid ReplicationController"* ]]
   [[ "${lines[2]}" == *"The file fixtures/valid.yaml contains a valid ReplicationController"* ]]
 }
+
+@test "Does not print warnings if --quiet is supplied" {
+  run bin/kubeval --ignore-missing-schemas --quiet fixtures/valid.yaml
+  [ "$status" -eq 0 ]
+  [ "$output" = "The file fixtures/valid.yaml contains a valid ReplicationController" ]
+}

--- a/kubeval/config.go
+++ b/kubeval/config.go
@@ -53,6 +53,10 @@ type Config struct {
 	// OutputFormat is the name of the output formatter which will be used when
 	// reporting results to the user.
 	OutputFormat string
+
+	// Quiet indicates whether non-results output should be emitted to the applications
+	// log.
+	Quiet bool
 }
 
 // NewDefaultConfig creates a Config with default values
@@ -72,9 +76,10 @@ func AddKubevalFlags(cmd *cobra.Command, config *Config) *cobra.Command {
 	cmd.Flags().StringVarP(&config.FileName, "filename", "f", "stdin", "filename to be displayed when testing manifests read from stdin")
 	cmd.Flags().StringSliceVar(&config.KindsToSkip, "skip-kinds", []string{}, "Comma-separated list of case-sensitive kinds to skip when validating against schemas")
 	cmd.Flags().StringVarP(&config.SchemaLocation, "schema-location", "s", "", "Base URL used to download schemas. Can also be specified with the environment variable KUBEVAL_SCHEMA_LOCATION.")
-	cmd.Flags().StringSliceVar(&config.AdditionalSchemaLocations , "additional-schema-locations", []string{}, "Comma-seperated list of secondary base URLs used to download schemas")
+	cmd.Flags().StringSliceVar(&config.AdditionalSchemaLocations, "additional-schema-locations", []string{}, "Comma-seperated list of secondary base URLs used to download schemas")
 	cmd.Flags().StringVarP(&config.KubernetesVersion, "kubernetes-version", "v", "master", "Version of Kubernetes to validate against")
 	cmd.Flags().StringVarP(&config.OutputFormat, "output", "o", "", fmt.Sprintf("The format of the output of this script. Options are: %v", validOutputs()))
+	cmd.Flags().BoolVar(&config.Quiet, "quiet", false, "Silences any output aside from the direct results")
 
 	return cmd
 }

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ var RootCmd = &cobra.Command{
 	Long:    `Validate a Kubernetes YAML file against the relevant schema`,
 	Version: fmt.Sprintf("Version: %s\nCommit: %s\nDate: %s\n", version, commit, date),
 	Run: func(cmd *cobra.Command, args []string) {
-		if config.IgnoreMissingSchemas {
+		if config.IgnoreMissingSchemas && !config.Quiet {
 			log.Warn("Warning: Set to ignore missing schemas")
 		}
 		success := true


### PR DESCRIPTION
Adds a `--quiet` flag for suppressing "non terminal" i.e. `error` or `result` messages from the kubeval logs. 

This will help users who are running kubeval in CI or other automated systems capture only the results they care about.

## Examples:

**Normal output**

```console
⇒  ./bin/kubeval -o json --ignore-missing-schemas fixtures/valid.yaml        
Warning: Set to ignore missing schemas
[
        {
                "filename": "fixtures/valid.yaml",
                "kind": "ReplicationController",
                "status": "valid",
                "errors": []
        }
]
```
**Flag enabled**

```console
⇒  ./bin/kubeval -o json --ignore-missing-schemas --quiet fixtures/valid.yaml
[
        {
                "filename": "fixtures/valid.yaml",
                "kind": "ReplicationController",
                "status": "valid",
                "errors": []
        }
]
```
