### PR TITLE
find yml files also when specified -d flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func aggregateFiles(args []string) ([]string, error) {
 			if err != nil {
 				return err
 			}
-			if !info.IsDir() && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml") {
+			if !info.IsDir() && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml")) {
 				files = append(files, path)
 			}
 			return nil

--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func aggregateFiles(args []string) ([]string, error) {
 			if err != nil {
 				return err
 			}
-			if !info.IsDir() && strings.HasSuffix(info.Name(), ".yaml") {
+			if !info.IsDir() && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml") {
 				files = append(files, path)
 			}
 			return nil


### PR DESCRIPTION
This will allow the auto-detection of `*.yaml` and `*.yml` files.  

fixes issue #178