### PR TITLE
Detect duplicate resources (same [API version, kind, namespace, name])

### DIFF
--- a/fixtures/duplicates-non-namespaced.yaml
+++ b/fixtures/duplicates-non-namespaced.yaml
@@ -1,0 +1,39 @@
+# Two objects with same name in same namespace, resource of non-namespaced kind
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv0003
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  storageClassName: slow
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+  nfs:
+    path: /tmp
+    server: 172.17.0.2
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv0003
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  storageClassName: slow
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+  nfs:
+    path: /tmp
+    server: 172.17.0.2

--- a/fixtures/duplicates-skipped-kinds.yaml
+++ b/fixtures/duplicates-skipped-kinds.yaml
@@ -1,0 +1,41 @@
+# Two objects with same name in same namespace, but of a kind configured to be skipped
+
+apiVersion: v1
+kind: SkipThisKind
+metadata:
+  name: "identical"
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: SkipThisKind
+metadata:
+  name: "identical"
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/fixtures/duplicates-with-namespace-default.yaml
+++ b/fixtures/duplicates-with-namespace-default.yaml
@@ -1,0 +1,43 @@
+# Two objects with same name in same namespace (one of them not given, i.e. will use default namespace as passed to kubeval)
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+  namespace: the-default-namespace
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+  # namespace not given
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/fixtures/duplicates-with-namespace.yaml
+++ b/fixtures/duplicates-with-namespace.yaml
@@ -1,0 +1,43 @@
+# Two objects with same name in same namespace
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+  namespace: x
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+  namespace: x
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/fixtures/duplicates.yaml
+++ b/fixtures/duplicates.yaml
@@ -1,0 +1,41 @@
+# Two objects with same name in same namespace
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/fixtures/same-kind-different-api.yaml
+++ b/fixtures/same-kind-different-api.yaml
@@ -1,0 +1,49 @@
+# Two objects with same name in same namespace, and having the same kind, but
+# of different API (apps/v1 vs. apps/v1beta1). This is important when CRDs
+# introduce overlapping `metadata:name` values, e.g. `Deployment` in
+# `my-awesome-cd-tool.io/v1` (contrived scenario).
+
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/fixtures/same-object-different-namespace-default.yaml
+++ b/fixtures/same-object-different-namespace-default.yaml
@@ -1,0 +1,43 @@
+# Two objects with same name in different namespace, one of them being the configured default namespace
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+  namespace: a
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+  namespace: the-default-namespace
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/fixtures/same-object-different-namespace.yaml
+++ b/fixtures/same-object-different-namespace.yaml
@@ -1,0 +1,43 @@
+# Two objects with same name in different namespace
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+  namespace: a
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "bob"
+  namespace: b
+spec:
+  replicas: 2
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20180715050151-f15292f7a699 // indirect
 	github.com/pelletier/go-toml v0.0.0-20180724185102-c2dbbc24a979 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/spf13/afero v1.1.1 // indirect
 	github.com/spf13/cast v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.0-20180820174524-ff0d02e85550

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/mitchellh/mapstructure v0.0.0-20180715050151-f15292f7a699 h1:KXZJFdun
 github.com/mitchellh/mapstructure v0.0.0-20180715050151-f15292f7a699/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v0.0.0-20180724185102-c2dbbc24a979 h1:Uh8pTMDzw+nuDTW7lyxcpmYqQJFE8SnO93F3lyY4XzY=
 github.com/pelletier/go-toml v0.0.0-20180724185102-c2dbbc24a979/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/afero v1.1.1 h1:Lt3ihYMlE+lreX1GS4Qw4ZsNpYQLxIXKBTEOXm3nt6I=

--- a/kubeval/config.go
+++ b/kubeval/config.go
@@ -14,6 +14,12 @@ const OpenShiftSchemaLocation = "https://raw.githubusercontent.com/garethr/opens
 
 // A Config object contains various configuration data for kubeval
 type Config struct {
+	// DefaultNamespace is the namespace to assume in resources
+	// if no namespace is set in `metadata:namespace` (as used with
+	// `kubectl apply --namespace ...` or `helm install --namespace ...`,
+	// for example)
+	DefaultNamespace string
+
 	// KubernetesVersion represents the version of Kubernetes
 	// for which we should load the schema
 	KubernetesVersion string
@@ -69,6 +75,7 @@ type Config struct {
 // NewDefaultConfig creates a Config with default values
 func NewDefaultConfig() *Config {
 	return &Config{
+		DefaultNamespace:  "default",
 		FileName:          "stdin",
 		KubernetesVersion: "master",
 	}
@@ -76,6 +83,7 @@ func NewDefaultConfig() *Config {
 
 // AddKubevalFlags adds the default flags for kubeval to cmd
 func AddKubevalFlags(cmd *cobra.Command, config *Config) *cobra.Command {
+	cmd.Flags().StringVarP(&config.DefaultNamespace, "default-namespace", "n", "default", "Namespace to assume in resources if no namespace is set in metadata:namespace")
 	cmd.Flags().BoolVar(&config.ExitOnError, "exit-on-error", false, "Immediately stop execution when the first error is encountered")
 	cmd.Flags().BoolVar(&config.IgnoreMissingSchemas, "ignore-missing-schemas", false, "Skip validation for resource definitions without a schema")
 	cmd.Flags().BoolVar(&config.OpenShift, "openshift", false, "Use OpenShift schemas instead of upstream Kubernetes")

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -35,15 +35,21 @@ func TestValidateValidInputs(t *testing.T) {
 		"full_domain_group.yaml",
 		"unconventional_keys.yaml",
 		"list_valid.yaml",
+		"same-object-different-namespace.yaml",
+		"same-object-different-namespace-default.yaml",
+		"duplicates-skipped-kinds.yaml",
+		"same-kind-different-api.yaml",
 	}
 	for _, test := range tests {
 		filePath, _ := filepath.Abs("../fixtures/" + test)
 		fileContents, _ := ioutil.ReadFile(filePath)
 		config := NewDefaultConfig()
+		config.DefaultNamespace = "the-default-namespace"
 		config.FileName = test
+		config.KindsToSkip = []string{"SkipThisKind"}
 		_, err := Validate(fileContents, config)
 		if err != nil {
-			t.Errorf("Validate should pass when testing valid configuration in " + test)
+			t.Errorf("Validate should pass when testing valid configuration in %s, got errors: %v", test, err)
 		}
 	}
 }
@@ -62,6 +68,9 @@ func TestValidateValidInputsWithCache(t *testing.T) {
 		"full_domain_group.yaml",
 		"unconventional_keys.yaml",
 		"list_valid.yaml",
+		"same-object-different-namespace.yaml",
+		"same-object-different-namespace-default.yaml",
+		"duplicates-skipped-kinds.yaml",
 	}
 	schemaCache := make(map[string]*gojsonschema.Schema, 0)
 
@@ -69,7 +78,9 @@ func TestValidateValidInputsWithCache(t *testing.T) {
 		filePath, _ := filepath.Abs("../fixtures/" + test)
 		fileContents, _ := ioutil.ReadFile(filePath)
 		config := NewDefaultConfig()
+		config.DefaultNamespace = "the-default-namespace"
 		config.FileName = test
+		config.KindsToSkip = []string{"SkipThisKind"}
 		_, err := ValidateWithCache(fileContents, schemaCache, config)
 		if err != nil {
 			t.Errorf("Validate should pass when testing valid configuration in " + test)
@@ -81,11 +92,15 @@ func TestValidateInvalidInputs(t *testing.T) {
 	var tests = []string{
 		"missing_kind.yaml",
 		"missing_kind_value.yaml",
+		"duplicates.yaml",
+		"duplicates-non-namespaced.yaml",
+		"duplicates-with-namespace.yaml",
 	}
 	for _, test := range tests {
 		filePath, _ := filepath.Abs("../fixtures/" + test)
 		fileContents, _ := ioutil.ReadFile(filePath)
 		config := NewDefaultConfig()
+		config.DefaultNamespace = "the-default-namespace"
 		config.FileName = test
 		_, err := Validate(fileContents, config)
 		if err == nil {

--- a/kubeval/utils.go
+++ b/kubeval/utils.go
@@ -7,6 +7,21 @@ import (
 	"strings"
 )
 
+func getObject(body map[string]interface{}, key string) (map[string]interface{}, error) {
+	value, found := body[key]
+	if !found {
+		return nil, fmt.Errorf("Missing '%s' key", key)
+	}
+	if value == nil {
+		return nil, fmt.Errorf("Missing '%s' value", key)
+	}
+	typedValue, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Expected object value for key '%s'", key)
+	}
+	return typedValue, nil
+}
+
 func getStringAt(body map[string]interface{}, path []string) (string, error) {
 	obj := body
 	visited := []string{}


### PR DESCRIPTION
Introduces `-n/--default-namespace` to specify which namespace a resource would be assigned if none is explicitly defined in the manifest. Exhaustively tested.