### PR TITLE
Add latest release link to installation docs.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ directly or place it on your path.
 ## Linux
 
 ```
-wget https://github.com/instrumenta/kubeval/releases/download/0.9.2/kubeval-linux-amd64.tar.gz
+wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
 tar xf kubeval-linux-amd64.tar.gz
 sudo cp kubeval /usr/local/bin
 ```
@@ -18,7 +18,7 @@ sudo cp kubeval /usr/local/bin
 ## macOS
 
 ```
-wget https://github.com/instrumenta/kubeval/releases/download/0.9.2/kubeval-darwin-amd64.tar.gz
+wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-darwin-amd64.tar.gz
 tar xf kubeval-darwin-amd64.tar.gz
 sudo cp kubeval /usr/local/bin
 ```


### PR DESCRIPTION
Today I installed kubeval and got an error because I tried to use a feature not present in the version pointed in the documentation to install so I made this small change to have docs always updated.