### PR TITLE
feat: adjust help when used as kubectl plugin

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -169,3 +169,11 @@
   [ "$status" -eq 0 ]
   [ "$output" = "PASS - fixtures/valid.yaml contains a valid ReplicationController" ]
 }
+
+@test "Adjusts help string when invoked as a kubectl plugin" {
+  ln -s kubeval bin/kubectl-kubeval
+
+  run bin/kubectl-kubeval --help
+  [ "$status" -eq 0 ]
+  [[ ${lines[2]} == "  kubectl kubeval <file>"* ]]
+}

--- a/main.go
+++ b/main.go
@@ -35,7 +35,6 @@ var (
 
 // RootCmd represents the the command to run when kubeval is run
 var RootCmd = &cobra.Command{
-	Use:     "kubeval <file> [file...]",
 	Short:   "Validate a Kubernetes YAML file against the relevant schema",
 	Long:    `Validate a Kubernetes YAML file against the relevant schema`,
 	Version: fmt.Sprintf("Version: %s\nCommit: %s\nDate: %s\n", version, commit, date),
@@ -196,6 +195,11 @@ func Execute() {
 }
 
 func init() {
+	rootCmdName := filepath.Base(os.Args[0])
+	if strings.HasPrefix(rootCmdName, "kubectl-") {
+		rootCmdName = strings.Replace(rootCmdName, "-", " ", 1)
+	}
+	RootCmd.Use = fmt.Sprintf("%s <file> [file...]", rootCmdName)
 	kubeval.AddKubevalFlags(RootCmd, config)
 	RootCmd.Flags().BoolVarP(&forceColor, "force-color", "", false, "Force colored output even if stdout is not a TTY")
 	RootCmd.SetVersionTemplate(`{{.Version}}`)


### PR DESCRIPTION

Change the usage message in help output to include the binary name the
command was invoked as, and also adjust it to match kubectl plugin
conventions when the binary name starts with `kubectl-`.

closes #187