### PR TITLE
Add support for --insecure-skip-tls-verify option

### DIFF
--- a/kubeval/config.go
+++ b/kubeval/config.go
@@ -57,6 +57,10 @@ type Config struct {
 	// Quiet indicates whether non-results output should be emitted to the applications
 	// log.
 	Quiet bool
+
+	// InsecureSkipTLSVerify controls whether to skip TLS certificate validation
+	// when retrieving schema content over HTTPS
+	InsecureSkipTLSVerify bool
 }
 
 // NewDefaultConfig creates a Config with default values
@@ -80,6 +84,7 @@ func AddKubevalFlags(cmd *cobra.Command, config *Config) *cobra.Command {
 	cmd.Flags().StringVarP(&config.KubernetesVersion, "kubernetes-version", "v", "master", "Version of Kubernetes to validate against")
 	cmd.Flags().StringVarP(&config.OutputFormat, "output", "o", "", fmt.Sprintf("The format of the output of this script. Options are: %v", validOutputs()))
 	cmd.Flags().BoolVar(&config.Quiet, "quiet", false, "Silences any output aside from the direct results")
+	cmd.Flags().BoolVar(&config.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
 
 	return cmd
 }

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -188,7 +188,7 @@ func downloadSchema(resource *ValidationResult, schemaCache map[string]*gojsonsc
 			return schema, nil
 		}
 		// We couldn't find a schema for this URL, so take a note, then try the next URL
-		wrappedErr := fmt.Errorf("Failed initalizing schema %s: %s", schemaRef, err)
+		wrappedErr := fmt.Errorf("Failed initializing schema %s: %s", schemaRef, err)
 		errors = multierror.Append(errors, wrappedErr)
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,6 +45,17 @@ var RootCmd = &cobra.Command{
 		if config.IgnoreMissingSchemas && !config.Quiet {
 			log.Warn("Set to ignore missing schemas")
 		}
+
+		// This is not particularly secure but we highlight that with the name of
+		// the config item. It would be good to also support a configurable set of
+		// trusted certificate authorities as in the `--certificate-authority`
+		// kubectl option.
+		if config.InsecureSkipTLSVerify {
+			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
+			}
+		}
+
 		success := true
 		windowsStdinIssue := false
 		outputManager := kubeval.GetOutputManager(config.OutputFormat)


### PR DESCRIPTION
Some users are stuck behind corporate HTTP proxies that MITM all traffic and are forced to sacrifice TLS security. This allows those users to use the tool despite the proxy messing with the certificates.

It would be great to continue down this path and provide a more secure option, like what `kubectl` does with the `--certificate-authority` option.

Fixes #197.
