### PR TITLE
Validate using multiple go routines

### DIFF
--- a/kubeval/config.go
+++ b/kubeval/config.go
@@ -2,7 +2,6 @@ package kubeval
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 )
 

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -40,6 +40,15 @@ func (v *ValidationResult) VersionKind() string {
 	return v.APIVersion + "/" + v.Kind
 }
 
+func SetupFormatCheckers() {
+	// Without forcing these types the schema fails to load
+	// Need to Work out proper handling for these types
+	gojsonschema.FormatCheckers.Add("int64", ValidFormat{})
+	gojsonschema.FormatCheckers.Add("byte", ValidFormat{})
+	gojsonschema.FormatCheckers.Add("int32", ValidFormat{})
+	gojsonschema.FormatCheckers.Add("int-or-string", ValidFormat{})
+}
+
 func determineSchemaURL(baseURL, kind, apiVersion string, config *Config) string {
 	// We have both the upstream Kubernetes schemas and the OpenShift schemas available
 	// the tool can toggle between then using the config.OpenShift boolean flag and here we

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ var RootCmd = &cobra.Command{
 		if forceColor {
 			color.NoColor = false
 		}
+
 		// We detect whether we have anything on stdin to process if we have no arguments
 		// or if the argument is a -
 		if (len(args) < 1 || args[0] == "-") && !windowsStdinIssue && ((stat.Mode() & os.ModeCharDevice) == 0) {


### PR DESCRIPTION
:thinking: This makes kubeval use multiple goroutines when dealing with multiple files / folders - on my laptop that's roughly a 5x improvement in speed.

It's quite a significant change however, so I would welcome code review, especially around the "gojsonschema.FormatCheckers.Add"  - are these still needed? Removing them did not cause any acceptance test to fail. If they are needed, then bad luck for me, and this PR won't work unless a lot of mutexes are added to gojsonschema :)

Unit & acceptance tests still pass.