### PR TITLE
Cache schema misses if missing schemas allowed

### DIFF
--- a/fixtures/test_crd.yaml
+++ b/fixtures/test_crd.yaml
@@ -7,3 +7,12 @@ metadata:
 spec:
   encryptedData:
     SOME_ENCRYPTED_DATA: c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: test-secret-clone
+  namespace: test-namespace
+spec:
+  encryptedData:
+    SOME_ENCRYPTED_DATA: c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -196,9 +196,8 @@ func downloadSchema(resource *ValidationResult, schemaCache map[string]*gojsonsc
 		errors.ErrorFormat = singleLineErrorFormat
 	}
 
-	// TODO: this currently triggers a segfault in offline cases
-	// We couldn't find a schema for this resource. Cache it's lack of existence, then stop
-	//schemaCache[resource.VersionKind()] = nil
+	// We couldn't find a schema for this resource. Cache its lack of existence
+	schemaCache[resource.VersionKind()] = nil
 	return nil, errors.ErrorOrNil()
 }
 

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -135,7 +135,7 @@ func validateResource(data []byte, schemaCache map[string]*gojsonschema.Schema, 
 func validateAgainstSchema(body interface{}, resource *ValidationResult, schemaCache map[string]*gojsonschema.Schema, config *Config) ([]gojsonschema.ResultError, error) {
 
 	schema, err := downloadSchema(resource, schemaCache, config)
-	if err != nil {
+	if err != nil || schema == nil {
 		return handleMissingSchema(err, config)
 	}
 
@@ -161,6 +161,7 @@ func validateAgainstSchema(body interface{}, resource *ValidationResult, schemaC
 	return []gojsonschema.ResultError{}, nil
 }
 
+// returned schema may be nil scehma is missing and missing schemas are allowed
 func downloadSchema(resource *ValidationResult, schemaCache map[string]*gojsonschema.Schema, config *Config) (*gojsonschema.Schema, error) {
 	if schema, ok := schemaCache[resource.VersionKind()]; ok {
 		// If the schema was previously cached, there's no work to be done


### PR DESCRIPTION
I've noticed that kubeval was MUCH slower after upgrading from 0.11.0 to 0.14.0. It turns out the schema server kubeval is hitting is very slow in returning 404s (like 15-30 seconds), so if you have a lot of custom resources, you're going to be waiting a long time if there's no caching. While it would be nice to make the server faster, there's no reason to not cache the schema misses.

I noticed that there was a commented-out line that explained why it wasn't done, so I modified a test to reproduce the error mentioned in the comment and then changed the code to fix the nil reference.