### PR TITLE
Make --strict validation errors an Err instead of Warn

### DIFF
--- a/kubeval/output.go
+++ b/kubeval/output.go
@@ -61,7 +61,7 @@ func newSTDOutputManager() *STDOutputManager {
 func (s *STDOutputManager) Put(result ValidationResult) error {
 	if len(result.Errors) > 0 {
 		for _, desc := range result.Errors {
-			kLog.Warn(result.FileName, "contains an invalid", result.Kind, "-", desc.String())
+			kLog.Error(fmt.Errorf("%v contains an invalid %v - %v", result.FileName, result.Kind, desc))
 		}
 	} else if result.Kind == "" {
 		kLog.Success(result.FileName, "contains an empty YAML document")


### PR DESCRIPTION
Other warnings may appear that don't cause validation to fail, making
this an error will make it easier to find what caused validation to
fail.