### PR TITLE
Fix long lines not working over stdin

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -82,10 +82,11 @@ var RootCmd = &cobra.Command{
 		notty := (stat.Mode() & os.ModeCharDevice) == 0
 		noFileOrDirArgs := (len(args) < 1 || args[0] == "-") && len(directories) < 1
 		if noFileOrDirArgs && !windowsStdinIssue && notty {
-			var buffer bytes.Buffer
-			scanner := bufio.NewScanner(os.Stdin)
-			for scanner.Scan() {
-				buffer.WriteString(scanner.Text() + "\n")
+			buffer := new(bytes.Buffer)
+			_, err := io.Copy(buffer, os.Stdin)
+			if err != nil {
+				log.Error(err)
+				os.Exit(1)
 			}
 			schemaCache := kubeval.NewSchemaCache()
 			config.FileName = viper.GetString("filename")


### PR DESCRIPTION
Currently, piping a manifest with very long lines subtly breaks kubeval. The `bufio.Scanner` used is not checked for errors after use, and for lines longer than 64k (https://github.com/golang/go/blob/go1.14/src/bufio/scan.go#L79) this means missing an `ErrTooLong`. Since the error is never checked, kubeval assumes the full input has been read, and validates whatever it managed to read.

We ran into this because of a ConfigMap with a `binaryData` segment of a couple hundred kilobytes.

This PR removes the Scanner and just uses `io.Copy` instead.

ping @garethr 