### PR TITLE
Adds qualified names to output

### DIFF
--- a/kubeval/output.go
+++ b/kubeval/output.go
@@ -61,14 +61,14 @@ func newSTDOutputManager() *STDOutputManager {
 func (s *STDOutputManager) Put(result ValidationResult) error {
 	if len(result.Errors) > 0 {
 		for _, desc := range result.Errors {
-			kLog.Warn(result.FileName, "contains an invalid", result.Kind, "-", desc.String())
+			kLog.Warn(result.FileName, "contains an invalid", result.Kind, "(", result.QualifiedName(), ")", "-", desc.String())
 		}
 	} else if result.Kind == "" {
 		kLog.Success(result.FileName, "contains an empty YAML document")
 	} else if !result.ValidatedAgainstSchema {
-		kLog.Warn(result.FileName, "containing a", result.Kind, "was not validated against a schema")
+		kLog.Warn(result.FileName, "containing a", result.Kind, "(", result.QualifiedName(), ")", "was not validated against a schema")
 	} else {
-		kLog.Success(result.FileName, "contains a valid", result.Kind)
+		kLog.Success(result.FileName, "contains a valid", result.Kind, "(", result.QualifiedName(), ")")
 	}
 
 	return nil

--- a/kubeval/utils.go
+++ b/kubeval/utils.go
@@ -4,7 +4,34 @@ import (
 	"bytes"
 	"fmt"
 	"runtime"
+	"strings"
 )
+
+func getStringAt(body map[string]interface{}, path []string) (string, error) {
+	obj := body
+	visited := []string{}
+	var last interface{} = body
+	for _, key := range path {
+		visited = append(visited, key)
+
+		typed, ok := last.(map[string]interface{})
+		if !ok {
+			return "", fmt.Errorf("Expected object at key '%s'", strings.Join(visited, "."))
+		}
+		obj = typed
+
+		value, found := obj[key]
+		if !found {
+			return "", fmt.Errorf("Missing '%s' key", strings.Join(visited, "."))
+		}
+		last = value
+	}
+	typed, ok := last.(string)
+	if !ok {
+		return "", fmt.Errorf("Expected string value for key '%s'", strings.Join(visited, "."))
+	}
+	return typed, nil
+}
 
 func getString(body map[string]interface{}, key string) (string, error) {
 	value, found := body[key]


### PR DESCRIPTION
This assists with finding issues in large collections of manifests. This is especially useful when used in conjunction with kustomize where the manifests are transformed and piped.