### PR TITLE
Add --reject-kinds flag

### DIFF
--- a/kubeval/config.go
+++ b/kubeval/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// schema validation
 	KindsToSkip []string
 
+	// KindsToReject is a list of case-sensitive prohibited kubernetes resources types
+	KindsToReject []string
+
 	// FileName is the name to be displayed when testing manifests read from stdin
 	FileName string
 
@@ -75,6 +78,7 @@ func AddKubevalFlags(cmd *cobra.Command, config *Config) *cobra.Command {
 	cmd.Flags().BoolVar(&config.Strict, "strict", false, "Disallow additional properties not in schema")
 	cmd.Flags().StringVarP(&config.FileName, "filename", "f", "stdin", "filename to be displayed when testing manifests read from stdin")
 	cmd.Flags().StringSliceVar(&config.KindsToSkip, "skip-kinds", []string{}, "Comma-separated list of case-sensitive kinds to skip when validating against schemas")
+	cmd.Flags().StringSliceVar(&config.KindsToReject, "reject-kinds", []string{}, "Comma-separated list of case-sensitive kinds to prohibit validating against schemas")
 	cmd.Flags().StringVarP(&config.SchemaLocation, "schema-location", "s", "", "Base URL used to download schemas. Can also be specified with the environment variable KUBEVAL_SCHEMA_LOCATION.")
 	cmd.Flags().StringSliceVar(&config.AdditionalSchemaLocations, "additional-schema-locations", []string{}, "Comma-seperated list of secondary base URLs used to download schemas")
 	cmd.Flags().StringVarP(&config.KubernetesVersion, "kubernetes-version", "v", "master", "Version of Kubernetes to validate against")

--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -124,6 +124,10 @@ func validateResource(data []byte, schemaCache map[string]*gojsonschema.Schema, 
 		return result, nil
 	}
 
+	if in(config.KindsToReject, kind) {
+		return result, fmt.Errorf("Prohibited resourse kind '%s' in %s", kind, result.FileName)
+	}
+
 	schemaErrors, err := validateAgainstSchema(body, &result, schemaCache, config)
 	if err != nil {
 		return result, fmt.Errorf("%s: %s", result.FileName, err.Error())

--- a/kubeval/kubeval_test.go
+++ b/kubeval/kubeval_test.go
@@ -192,6 +192,41 @@ func TestValidateMultipleResourcesWithErrors(t *testing.T) {
 	}
 }
 
+func TestValidateKindsToReject(t *testing.T) {
+	var tests = []struct {
+		Name          string
+		KindsToReject []string
+		Fixture       string
+		Pass          bool
+	}{
+		{
+			Name:          "allow_all",
+			KindsToReject: []string{},
+			Fixture:       "valid.yaml",
+			Pass:          true,
+		},
+		{
+			Name:          "reject_one",
+			KindsToReject: []string{"ReplicationController"},
+			Fixture:       "valid.yaml",
+			Pass:          false,
+		},
+	}
+	schemaCache := make(map[string]*gojsonschema.Schema, 0)
+
+	for _, test := range tests {
+		filePath, _ := filepath.Abs("../fixtures/" + test.Fixture)
+		fileContents, _ := ioutil.ReadFile(filePath)
+		config := NewDefaultConfig()
+		config.FileName = test.Fixture
+		config.KindsToReject = test.KindsToReject
+		_, err := ValidateWithCache(fileContents, schemaCache, config)
+		if err != nil && test.Pass == true {
+			t.Errorf("Validate should pass when testing valid configuration in " + test.Name)
+		}
+	}
+}
+
 func TestDetermineSchemaURL(t *testing.T) {
 	var tests = []struct {
 		config   *Config


### PR DESCRIPTION
Adds the ability to specify a comma-delimited list of prohibited Kubernetes resource Kinds.

```
kubeval --exit-on-error --reject-kinds "Secret" -d ./workloads/example
PASS - workloads/example/deployment.yaml contains a valid Deployment
PASS - workloads/example/env.yaml contains a valid ConfigMap
ERR  - Prohibited resourse kind 'Secret' in workloads/example/secret.yaml
```

Fixes #225 