### PR TITLE
Changed ignored_filename_patterns to ignored_path_patterns

### DIFF
--- a/main.go
+++ b/main.go
@@ -241,7 +241,8 @@ func init() {
 	RootCmd.SetVersionTemplate(`{{.Version}}`)
 	RootCmd.Flags().StringSliceVarP(&directories, "directories", "d", []string{}, "A comma-separated list of directories to recursively search for YAML documents")
 	RootCmd.Flags().StringSliceVarP(&ignoredPathPatterns, "ignored-path-patterns", "i", []string{}, "A comma-separated list of regular expressions specifying paths to ignore")
-
+	RootCmd.Flags().StringSliceVarP(&ignoredPathPatterns, "ignored-filename-patterns", "", []string{}, "An alias for ignored-path-patterns")
+	
 	viper.SetEnvPrefix("KUBEVAL")
 	viper.AutomaticEnv()
 	viper.BindPFlag("schema_location", RootCmd.Flags().Lookup("schema-location"))

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 	commit                  = "none"
 	date                    = "unknown"
 	directories             = []string{}
-	ignoredFilenamePatterns = []string{}
+	ignoredPathPatterns = []string{}
 
 	// forceColor tells kubeval to use colored output even if
 	// stdout is not a TTY
@@ -175,9 +175,9 @@ func hasErrors(res []kubeval.ValidationResult) bool {
 }
 
 // isIgnored returns whether the specified filename should be ignored.
-func isIgnored(filename string) (bool, error) {
-	for _, p := range ignoredFilenamePatterns {
-		m, err := regexp.MatchString(p, filename)
+func isIgnored(path string) (bool, error) {
+	for _, p := range ignoredPathPatterns {
+		m, err := regexp.MatchString(p, path)
 		if err != nil {
 			return false, err
 		}
@@ -198,7 +198,7 @@ func aggregateFiles(args []string) ([]string, error) {
 			if err != nil {
 				return err
 			}
-			ignored, err := isIgnored(info.Name())
+			ignored, err := isIgnored(path)
 			if err != nil {
 				return err
 			}
@@ -240,7 +240,7 @@ func init() {
 	RootCmd.Flags().BoolVarP(&forceColor, "force-color", "", false, "Force colored output even if stdout is not a TTY")
 	RootCmd.SetVersionTemplate(`{{.Version}}`)
 	RootCmd.Flags().StringSliceVarP(&directories, "directories", "d", []string{}, "A comma-separated list of directories to recursively search for YAML documents")
-	RootCmd.Flags().StringSliceVarP(&ignoredFilenamePatterns, "ignored-filename-patterns", "i", []string{}, "A comma-separated list of regular expressions specifying filenames to ignore")
+	RootCmd.Flags().StringSliceVarP(&ignoredPathPatterns, "ignored-path-patterns", "i", []string{}, "A comma-separated list of regular expressions specifying paths to ignore")
 
 	viper.SetEnvPrefix("KUBEVAL")
 	viper.AutomaticEnv()


### PR DESCRIPTION
This PR changes the `-i/--ignored-filename-patterns` flag to `-i/--ignored-path-patterns`. As it allows more advanced configuration which files should be ignored. 
It works in a similar way like previously, so it accepts a list of directory patterns (regular expressions) to be ignored.
I've encountered difficulties with the previous solution when I wanted to configure the Github Actions for a repository used for GitOps approach. I wasn't able to run validation on all yaml files in any directory with exception of the `.github` directory. 
Now it's possible with passing `ignored_path_patterns="^\.github"`.