### PR TITLE
Add --failures-only option

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -177,3 +177,9 @@
   [ "$status" -eq 0 ]
   [[ ${lines[2]} == "  kubectl kubeval <file>"* ]]
 }
+
+@test "Only non-PASS messages are shown with --failures-only" {
+  run bin/kubeval --failures-only fixtures/valid.yaml fixtures/invalid.yaml
+  [ "$status" -eq 1 ]
+  [ "$output" = "WARN - fixtures/invalid.yaml contains an invalid ReplicationController (bob) - spec.replicas: Invalid type. Expected: [integer,null], given: string" ]
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,8 @@ PASS - chart/templates/primary.yaml contains a valid ReplicationControlle
 
 The output of `kubeval` can be configured using the `--output` flag (`-o`).
 
+If you only want to output files that contain errors use the `--failures-only` flag.
+
 As of today `kubeval` supports the following output types:
 
 - Plaintext `--output=stdout`
@@ -147,6 +149,7 @@ Usage:
 Flags:
   -d, --directories strings         A comma-separated list of directories to recursively search for YAML documents
       --exit-on-error               Immediately stop execution when the first error is encountered
+      --failures-only               If true, only files that fail validation will be included in the output.
   -f, --filename string             filename to be displayed when testing manifests read from stdin (default "stdin")
       --force-color                 Force colored output even if stdout is not a TTY
   -h, --help                        help for kubeval

--- a/kubeval/config.go
+++ b/kubeval/config.go
@@ -70,6 +70,9 @@ type Config struct {
 	// InsecureSkipTLSVerify controls whether to skip TLS certificate validation
 	// when retrieving schema content over HTTPS
 	InsecureSkipTLSVerify bool
+
+	// Output only those files that do not PASS
+	FailuresOnly bool
 }
 
 // NewDefaultConfig creates a Config with default values
@@ -97,6 +100,7 @@ func AddKubevalFlags(cmd *cobra.Command, config *Config) *cobra.Command {
 	cmd.Flags().StringVarP(&config.OutputFormat, "output", "o", "", fmt.Sprintf("The format of the output of this script. Options are: %v", validOutputs()))
 	cmd.Flags().BoolVar(&config.Quiet, "quiet", false, "Silences any output aside from the direct results")
 	cmd.Flags().BoolVar(&config.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure")
+	cmd.Flags().BoolVar(&config.FailuresOnly, "failures-only", false, "If true, only files that fail validation will be included in the output.")
 
 	return cmd
 }

--- a/kubeval/output.go
+++ b/kubeval/output.go
@@ -36,26 +36,29 @@ func validOutputs() []string {
 	}
 }
 
-func GetOutputManager(outFmt string) outputManager {
+func GetOutputManager(outFmt string, failuresOnly bool) outputManager {
 	switch outFmt {
 	case outputSTD:
-		return newSTDOutputManager()
+		return newSTDOutputManager(failuresOnly)
 	case outputJSON:
-		return newDefaultJSONOutputManager()
+		return newDefaultJSONOutputManager(failuresOnly)
 	case outputTAP:
-		return newDefaultTAPOutputManager()
+		return newDefaultTAPOutputManager(failuresOnly)
 	default:
-		return newSTDOutputManager()
+		return newSTDOutputManager(failuresOnly)
 	}
 }
 
 // STDOutputManager reports `kubeval` results to stdout.
 type STDOutputManager struct {
+	FailuresOnly bool
 }
 
 // newSTDOutputManager instantiates a new instance of STDOutputManager.
-func newSTDOutputManager() *STDOutputManager {
-	return &STDOutputManager{}
+func newSTDOutputManager(failuresOnly bool) *STDOutputManager {
+	return &STDOutputManager{
+		FailuresOnly: failuresOnly,
+	}
 }
 
 func (s *STDOutputManager) Put(result ValidationResult) error {
@@ -63,11 +66,11 @@ func (s *STDOutputManager) Put(result ValidationResult) error {
 		for _, desc := range result.Errors {
 			kLog.Warn(result.FileName, "contains an invalid", result.Kind, fmt.Sprintf("(%s)", result.QualifiedName()), "-", desc.String())
 		}
-	} else if result.Kind == "" {
+	} else if result.Kind == "" && !s.FailuresOnly {
 		kLog.Success(result.FileName, "contains an empty YAML document")
 	} else if !result.ValidatedAgainstSchema {
 		kLog.Warn(result.FileName, "containing a", result.Kind, fmt.Sprintf("(%s)", result.QualifiedName()), "was not validated against a schema")
-	} else {
+	} else if !s.FailuresOnly {
 		kLog.Success(result.FileName, "contains a valid", result.Kind, fmt.Sprintf("(%s)", result.QualifiedName()))
 	}
 
@@ -99,15 +102,18 @@ type jsonOutputManager struct {
 	logger *log.Logger
 
 	data []dataEvalResult
+
+	FailuresOnly bool
 }
 
-func newDefaultJSONOutputManager() *jsonOutputManager {
-	return newJSONOutputManager(log.New(os.Stdout, "", 0))
+func newDefaultJSONOutputManager(failuresOnly bool) *jsonOutputManager {
+	return newJSONOutputManager(log.New(os.Stdout, "", 0), failuresOnly)
 }
 
-func newJSONOutputManager(l *log.Logger) *jsonOutputManager {
+func newJSONOutputManager(l *log.Logger, failuresOnly bool) *jsonOutputManager {
 	return &jsonOutputManager{
 		logger: l,
+		FailuresOnly: failuresOnly,
 	}
 }
 
@@ -136,12 +142,14 @@ func (j *jsonOutputManager) Put(r ValidationResult) error {
 		errs = append(errs, e.String())
 	}
 
-	j.data = append(j.data, dataEvalResult{
-		Filename: r.FileName,
-		Kind:     r.Kind,
-		Status:   getStatus(r),
-		Errors:   errs,
-	})
+	if getStatus(r) == statusValid && !j.FailuresOnly {
+		j.data = append(j.data, dataEvalResult{
+			Filename: r.FileName,
+			Kind:     r.Kind,
+			Status:   getStatus(r),
+			Errors:   errs,
+		})
+	}
 
 	return nil
 }
@@ -167,19 +175,22 @@ type tapOutputManager struct {
 	logger *log.Logger
 
 	data []dataEvalResult
+
+	FailuresOnly bool
 }
 
 // newDefaultTapOutManager instantiates a new instance of tapOutputManager
 // using the default logger.
-func newDefaultTAPOutputManager() *tapOutputManager {
-	return newTAPOutputManager(log.New(os.Stdout, "", 0))
+func newDefaultTAPOutputManager(failuresOnly bool) *tapOutputManager {
+	return newTAPOutputManager(log.New(os.Stdout, "", 0), failuresOnly)
 }
 
 // newTapOutputManager constructs an instance of tapOutputManager given a
 // logger instance.
-func newTAPOutputManager(l *log.Logger) *tapOutputManager {
+func newTAPOutputManager(l *log.Logger, failuresOnly bool) *tapOutputManager {
 	return &tapOutputManager{
 		logger: l,
+		FailuresOnly: failuresOnly,
 	}
 }
 
@@ -189,12 +200,14 @@ func (j *tapOutputManager) Put(r ValidationResult) error {
 		errs = append(errs, e.String())
 	}
 
-	j.data = append(j.data, dataEvalResult{
-		Filename: r.FileName,
-		Kind:     r.Kind,
-		Status:   getStatus(r),
-		Errors:   errs,
-	})
+	if getStatus(r) == statusValid && !j.FailuresOnly {
+		j.data = append(j.data, dataEvalResult{
+			Filename: r.FileName,
+			Kind:     r.Kind,
+			Status:   getStatus(r),
+			Errors:   errs,
+		})
+	}
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ var RootCmd = &cobra.Command{
 
 		success := true
 		windowsStdinIssue := false
-		outputManager := kubeval.GetOutputManager(config.OutputFormat)
+		outputManager := kubeval.GetOutputManager(config.OutputFormat, config.FailuresOnly)
 
 		stat, err := os.Stdin.Stat()
 		if err != nil {


### PR DESCRIPTION
👋 Would you be interested in this PR which adds a `--failures-only` option which only outputs non-PASSing results when specified. If not specified, the previous default behavior of outputting everything is left unchanged.

The motivation behind this change is that in repos with a large number of manifests it can be difficult to find the errors in the output when the majority of the manifests PASS.

❤️ Thanks for all the work on this project!
