### PR TITLE
Bump sigs.k8s.io/yaml to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.7.0
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357 // indirect
@@ -29,6 +28,5 @@ require (
 	github.com/xeipuuv/gojsonschema v0.0.0-20180816142147-da425ebb7609
 	golang.org/x/sys v0.0.0-20180821044426-4ea2f632f6e9 // indirect
 	golang.org/x/text v0.0.0-20180810153555-6e3c4e7365dd // indirect
-	gopkg.in/yaml.v2 v2.2.1 // indirect
-	sigs.k8s.io/yaml v1.1.0
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -56,7 +56,7 @@ golang.org/x/text v0.0.0-20180810153555-6e3c4e7365dd h1:e/dojZNNKqwK3xq7UQTKTQJi
 golang.org/x/text v0.0.0-20180810153555-6e3c4e7365dd/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
-gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
-sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=


### PR DESCRIPTION
Not sure where the bug was in the library (or what it was chocking on in the ConfigMap), but:

**Before:**

```shell
$ jsonnet -J vendor grafana-dashboard-apiserver.jsonnet | kubeval
ERR  - Failed to decode YAML from stdin: error converting YAML to JSON: yaml: line 3: did not find expected node content
```

**After:**

```shell
$ jsonnet -J vendor grafana-dashboard-apiserver.jsonnet | kubeval
PASS - stdin contains a valid ConfigMap (grafana.grafana-dashboard-apiserver)
```

Fixes https://github.com/instrumenta/kubeval/issues/241#issuecomment-670615573