### PR TITLE
Fix line count for errors on tap output

### DIFF
--- a/kubeval/output.go
+++ b/kubeval/output.go
@@ -225,9 +225,13 @@ func (j *tapOutputManager) Flush() error {
 			} else if r.Status == "skipped" {
 				j.logger.Print("ok ", count, " #skip - ", r.Filename, kindMarker)
 			} else if r.Status == "invalid" {
-				for _, e := range r.Errors {
+				for i, e := range r.Errors {
 					j.logger.Print("not ok ", count, " - ", r.Filename, kindMarker, " - ", e)
-					count = count + 1
+
+					// We have to skip adding 1 if it's the last error
+					if len(r.Errors) != i+1 {
+						count = count + 1
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the line count being incorrect on the tap output.
The previous code would work but only if the last file was the file that had an error.