### PR TITLE
fix: TAP Schema treats SKIP as a directive, at the end of the line

### DIFF
--- a/kubeval/output.go
+++ b/kubeval/output.go
@@ -223,7 +223,7 @@ func (j *tapOutputManager) Flush() error {
 			if r.Status == "valid" {
 				j.logger.Print("ok ", count, " - ", r.Filename, kindMarker)
 			} else if r.Status == "skipped" {
-				j.logger.Print("ok ", count, " #skip - ", r.Filename, kindMarker)
+				j.logger.Print("ok ", count, " - ", r.Filename, kindMarker, " # SKIP")
 			} else if r.Status == "invalid" {
 				for _, e := range r.Errors {
 					j.logger.Print("not ok ", count, " - ", r.Filename, kindMarker, " - ", e)

--- a/kubeval/output_test.go
+++ b/kubeval/output_test.go
@@ -165,6 +165,21 @@ not ok 1 - service.yaml (Service) - error: i am a error
 not ok 2 - service.yaml (Service) - error: i am another error
 `,
 		},
+		{
+			msg: "file with no errors because of a skip",
+			args: args{
+				vr: ValidationResult{
+					FileName:               "deployment.yaml",
+					Kind:                   "Deployment",
+					ValidatedAgainstSchema: true,
+					Errors:                 nil,
+				},
+			},
+			exp: `1..2
+ok 1 - validate.yaml (Validation) # SKIP
+ok 2 - deployment.yaml (Deployment)
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {


### PR DESCRIPTION
Playing around with tap-to-junit vlaidations I found that the only safe way
to get the skips parsed was to use capitalized `# SKIP` with the space after the description.

Technically lowercase seems to be allowed but the majority of the schema's
examples show capitalized.

https://testanything.org/tap-version-13-specification.html

In the schema it also says any explanation of why it was skipped should go
after the `# SKIP`, but the description of the test still goes to the left.

I wasn't sure what all would be necessary but it would be kewl to have the
returned status value for the reason they were skipped map to a string
to append to the line.
