### PR TITLE
Improvements to Homebrew installation command

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ For those using [Homebrew](https://brew.sh/) you can use the kubeval tap:
 
 ```
 brew tap instrumenta/instrumenta
-brew install kubeval
+brew install instrumenta/instrumenta/kubeval
 ```
 
 ## Windows


### PR DESCRIPTION
Thank you for your great OSS!

`kubeval` was previously distributed by @garethr , and if the tap command settings from that time are still in place, the following error will be displayed.

[![Image from Gyazo](https://i.gyazo.com/dd02087ef2740e1d4999ce5d305598c0.png)](https://gyazo.com/dd02087ef2740e1d4999ce5d305598c0)

Therefore, I would like to suggest that I change the documentation to fully qualified commands so as not to confuse users.

Could you give me some advice about this PR?

Thanks!