### PR TITLE
Update GoReleaser config to build arm binaries and tarballs explicitly

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,13 +7,19 @@ builds:
   goos:
   - windows
   - linux
-  - darwin 
+  - darwin
+  goarch:
+  - amd64
+  - arm
+  - arm64
+  goarm:
+  - 6
+  - 7
 archives:
 - format: tar.gz
   format_overrides:
   - goos: windows
     format: zip
-  name_template: "{{ .ProjectName  }}-{{ .Os  }}-{{ .Arch  }}"
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Closes https://github.com/instrumenta/kubeval/issues/291

This config makes GoReleaser _explicitly_ build `arm64` binaries and tarballs. The architecture has been added to the default list recently and releasing using an older version wouldn't include it (see https://github.com/goreleaser/goreleaser/commit/2edebf0029e8c5a873947306ee892f089438795f).