### PR TITLE
chore: gorelease to upstream repo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,8 +24,12 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+release:
+  github:
+    owner: instrumenta
+    name: kubeval
 brews:
-- github:
+- tap:
     owner: instrumenta
     name: homebrew-instrumenta
   folder: Formula


### PR DESCRIPTION
fix deprecation notice