### PR TITLE
fix: use different level for skipped schemas

### DIFF
--- a/kubeval/output.go
+++ b/kubeval/output.go
@@ -66,7 +66,7 @@ func (s *STDOutputManager) Put(result ValidationResult) error {
 	} else if result.Kind == "" {
 		kLog.Success(result.FileName, "contains an empty YAML document")
 	} else if !result.ValidatedAgainstSchema {
-		kLog.Warn(result.FileName, "containing a", result.Kind, fmt.Sprintf("(%s)", result.QualifiedName()), "was not validated against a schema")
+		kLog.Info(result.FileName, "containing a", result.Kind, fmt.Sprintf("(%s)", result.QualifiedName()), "was not validated against a schema")
 	} else {
 		kLog.Success(result.FileName, "contains a valid", result.Kind, fmt.Sprintf("(%s)", result.QualifiedName()))
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -13,6 +13,11 @@ func Success(message ...string) {
 	fmt.Printf("%s - %v\n", green("PASS"), strings.Join(message, " "))
 }
 
+func Info(message ...string) {
+	blue := color.New(color.FgBlue).SprintFunc()
+	fmt.Printf("%s - %v\n", blue("PASS"), strings.Join(message, " "))
+}
+
 func Warn(message ...string) {
 	yellow := color.New(color.FgYellow).SprintFunc()
 	fmt.Printf("%s - %v\n", yellow("WARN"), strings.Join(message, " "))


### PR DESCRIPTION
lets not use the same warning level for skipped schemas as we do for actual validation errors

so that its easy to tell the output difference between actual schema validation errors versus CRD kinds that are skipped