### PR TITLE
chore: bump go to 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.15-node
+      - image: cimg/go:1.17-node
 
     steps: 
       - checkout 


### PR DESCRIPTION
Use the next-gen language images as per
https://circleci.com/docs/2.0/circleci-images/

Change proposed to create a new build which will pick up
https://github.com/goreleaser/goreleaser/pull/2591