### PR TITLE
OutputManager handles error output

### DIFF
--- a/kubeval/kubeval.go
+++ b/kubeval/kubeval.go
@@ -138,13 +138,13 @@ func validateResource(data []byte, schemaCache map[string]*gojsonschema.Schema, 
 
 	kind, err := getString(body, "kind")
 	if err != nil {
-		return result, body, fmt.Errorf("%s: %s", result.FileName, err.Error())
+		return result, body, fmt.Errorf(err.Error())
 	}
 	result.Kind = kind
 
 	apiVersion, err := getString(body, "apiVersion")
 	if err != nil {
-		return result, body, fmt.Errorf("%s: %s", result.FileName, err.Error())
+		return result, body, fmt.Errorf(err.Error())
 	}
 	result.APIVersion = apiVersion
 

--- a/kubeval/utils.go
+++ b/kubeval/utils.go
@@ -51,14 +51,14 @@ func getStringAt(body map[string]interface{}, path []string) (string, error) {
 func getString(body map[string]interface{}, key string) (string, error) {
 	value, found := body[key]
 	if !found {
-		return "", fmt.Errorf("Missing '%s' key", key)
+		return "", fmt.Errorf("%s: %s key is required", key, key)
 	}
 	if value == nil {
-		return "", fmt.Errorf("Missing '%s' value", key)
+		return "", fmt.Errorf("%s: %s is missing a value", key, key)
 	}
 	typedValue, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("Expected string value for key '%s'", key)
+		return "", fmt.Errorf("%s: %s must have a string value", key, key)
 	}
 	return typedValue, nil
 }

--- a/main.go
+++ b/main.go
@@ -129,7 +129,10 @@ var RootCmd = &cobra.Command{
 				config.FileName = fileName
 				results, err := kubeval.ValidateWithCache(fileContents, schemaCache, config)
 				if err != nil {
-					log.Error(err)
+					err := outputManager.PutValidateError(err, *config)
+					if err != nil {
+						log.Error(err)
+					}
 					earlyExit()
 					success = false
 					continue
@@ -242,7 +245,7 @@ func init() {
 	RootCmd.Flags().StringSliceVarP(&directories, "directories", "d", []string{}, "A comma-separated list of directories to recursively search for YAML documents")
 	RootCmd.Flags().StringSliceVarP(&ignoredPathPatterns, "ignored-path-patterns", "i", []string{}, "A comma-separated list of regular expressions specifying paths to ignore")
 	RootCmd.Flags().StringSliceVarP(&ignoredPathPatterns, "ignored-filename-patterns", "", []string{}, "An alias for ignored-path-patterns")
-	
+
 	viper.SetEnvPrefix("KUBEVAL")
 	viper.AutomaticEnv()
 	viper.BindPFlag("schema_location", RootCmd.Flags().Lookup("schema-location"))


### PR DESCRIPTION
This pull request corrects output inconsistencies when errors are found before the configuration hits the schema validator. See: #332 

If one specifies the output type of json ```-o json``` and the config is missing 'apiversion' or 'kind' fields, the error output takes the form of a standard string.

Error handling currently bypasses the OutputManager and dumps errors to stdout as regular strings. This  update redirects error output to OutputManager. Kubeval still fails fast when a config is loaded that is missing the necessary fields.

Example of config output with and without changes:
```
# test.yaml

# apiVersion: apps/v1
kind: Deployment
metadata:
  name: moda-sandbox

```

Current output:
```
$ go run main.go -d test.yaml -o json
ERR  - test.yaml: Missing 'apiVersion' key
null
```

With updates:
```
[
        {
                "filename": "test.yaml",
                "kind": "",
                "status": "invalid",
                "errors": [
                        "apiVersion: apiVersion key is required"
                ]
        }
]
```

