### PR TITLE
docs: Remove tap from brew installation procedure

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,6 @@ sudo cp kubeval /usr/local/bin
 For those using [Homebrew](https://brew.sh/) you can use the kubeval tap:
 
 ```
-brew tap instrumenta/instrumenta
 brew install kubeval
 ```
 


### PR DESCRIPTION
`brew tap` seems to be no longer needed since kubeval is now on homebrew/core: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/kubeval.rb